### PR TITLE
Migrate to latest API and use idiomatic events

### DIFF
--- a/src/app/api/get_market_prices.ts
+++ b/src/app/api/get_market_prices.ts
@@ -2,36 +2,35 @@ export async function getMarketPrices() {
   const hourCount = 24 * 30 * 12
 
   const res = await fetch(
-      `https://api.energidataservice.dk/dataset/Elspotprices?limit=${hourCount}&offset=0&sort=HourUTC DESC&timezone=utc+1&filter={"PriceArea":"DK2"}`,
-      { next: { revalidate: 60*60 } }
-    )
-  const data = (await res.json()) as ElspotType
+      `https://api.energidataservice.dk/dataset/DayAheadPrices?limit=${hourCount}&offset=0&timezone=utc+1&filter={"PriceArea":"DK2"}`,
+      { next: { revalidate: 60 * 60 } }
+    );
+  const data = (await res.json()) as DayAheadPrices
 
   const prices = data.records.map(
-    ({ HourDK, SpotPriceEUR }) => {
-
-      const spotPriceEur = SpotPriceEUR
+    ({ TimeUTC, DayAheadPriceEUR }) => {
+      const spotPriceEur = DayAheadPriceEUR
       const eurToDkk = 7.45
       const dkkToOre = 100
       const mwtToKwt = 0.001
       const orePrKwt = spotPriceEur * mwtToKwt * eurToDkk * dkkToOre
 
       return {
-        date: new Date(HourDK),
-        orePrKwt: orePrKwt
+        date: new Date(TimeUTC),
+        orePrKwt: orePrKwt,
       }
     }
   )
   return prices
 }
 
-export type ElspotType = {
+export type DayAheadPrices = {
   dataset: string,
   records: {
-    HourDK: string
-    HourUTC: string
+    TimeDK: string
+    TimeUTC: string
     PriceArea: string
-    SpotPriceDKK: number
-    SpotPriceEUR: number
-  }[]
-}
+    DayAheadPriceDKK: number
+    DayAheadPriceEUR: number
+  }[];
+};

--- a/src/app/api/page.tsx
+++ b/src/app/api/page.tsx
@@ -1,9 +1,0 @@
-import { getData } from "./get_data"
-
-export default async function Api() {
-  const data = await getData()
-
-  return <>
-    { JSON.stringify(data) }
-  </>
-}

--- a/src/app/api/route.ts
+++ b/src/app/api/route.ts
@@ -1,0 +1,4 @@
+import { getData } from "./get_data"
+
+export const GET = async () => Response.json(await getData())
+

--- a/src/app/api/route.ts
+++ b/src/app/api/route.ts
@@ -1,4 +1,4 @@
+import { NextResponse } from 'next/server'
 import { getData } from "./get_data"
 
-export const GET = async () => Response.json(await getData())
-
+export const GET = async () => NextResponse.json(await getData())

--- a/src/app/components/InteractiveChart.tsx
+++ b/src/app/components/InteractiveChart.tsx
@@ -557,11 +557,12 @@ function findPrice(
   date: Date
 ) {
   const dateFloor = date
-  dateFloor.setMinutes(0, 0, 0)
+  const quarterHourOffset = Math.floor(date.getMinutes() / 60 * 4) * 15;
+  dateFloor.setMinutes(quarterHourOffset, 0, 0)
 
   const dateCeil = addHours(1, dateFloor)
 
-  
+
   for (let i = 0; i < data.length; i++) {
     const el = data[i];
     if (dateFloor <= el.date && el.date <= dateCeil) {


### PR DESCRIPTION
The Elspot endpoint is deprecated and no longer updated. It is replaced by the quarterly DayAheadPrices endpoint. This led to some challenges as the current implementation assumed hourly data. Merging this PR will

- Migrate to DayAheadPrices endpoint
- Refactor to idiomatic React events
- Simplify API endpoint

This should make the app router migration complete 🥳